### PR TITLE
github_commit_logs に "stats" の "total", "addition", "deletion" まで保存できるようにした

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -78,10 +78,19 @@ class Project < ApplicationRecord
     params['id'] = log['id'] # ?
     params['commit_id'] = log['sha']
     params['message'] = log['commit']['message'][0, 244] # 文字数上限を追加。
+    # 空なら取得しない。
+    if log['parents'] != []
+      @c_diffs_url = log['parents'][0]['url']
+      # 差分情報を取得
+      @commit_diffs = JSON.parse(`curl #{@c_diffs_url}`)
+      puts(@commit_diffs)
+      puts("\n@commit_diffs['stats'] : #{@commit_diffs['stats']}\n\n\n")
+      params['stats_total'] = @commit_diffs['stats']['total']
+      params['stats_add'] = @commit_diffs['stats']['additions']
+      params['stats_del'] = @commit_diffs['stats']['deletions']
+    end
     params['users_id'] = user.id
     params['project_id'] = id
-    # テスト用
-    #params['name'] = log['committer']['date']
-    params
+    return params
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -28,7 +28,7 @@ class Project < ApplicationRecord
     ###  エサを追加  ###
     @new_commit_logs = JSON.parse(`curl https://api.github.com/repos/#{self.user.username}/#{name}/commits`)
     # webhook までのつなぎ。
-    # 30までしか取得できないため、30以上は追加できない。
+    # 30以上も取得しようと思えばできるが、めんどくさくてやってない。（えさの鮮度的に、30でよくね？説はある）
     added_commit_num = get_added_commit_num(@new_commit_logs)
     if added_commit_num > 0
       self.commit_num += added_commit_num
@@ -73,7 +73,7 @@ class Project < ApplicationRecord
 
   def choose_log_data(log)
     # ここをいじると DB の内容が変わるので、github_commit_log を create し直す必要あり。
-    #   → 一括更新するメソッド書いた：rake init_github_commit_log:init
+    #   → 一括更新するメソッド書いた： $ rake init_github_commit_log:init
     params = {}
     params['id'] = log['id'] # ?
     params['commit_id'] = log['sha']

--- a/db/migrate/20181111055741_remove_name_from_github_commit_logs.rb
+++ b/db/migrate/20181111055741_remove_name_from_github_commit_logs.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromGithubCommitLogs < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :github_commit_logs, :name, :string
+  end
+end

--- a/db/migrate/20181111060348_add_details_to_github_commit_logs.rb
+++ b/db/migrate/20181111060348_add_details_to_github_commit_logs.rb
@@ -1,0 +1,7 @@
+class AddDetailsToGithubCommitLogs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :github_commit_logs, :stats_total, :integer
+    add_column :github_commit_logs, :stats_add, :integer
+    add_column :github_commit_logs, :stats_del, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_27_042829) do
+ActiveRecord::Schema.define(version: 2018_11_11_060348) do
 
   create_table "github_commit_logs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "users_id"
     t.bigint "project_id"
-    t.string "name"
     t.string "commit_id"
     t.string "message"
     t.integer "size"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "stats_total"
+    t.integer "stats_add"
+    t.integer "stats_del"
     t.index ["project_id"], name: "index_github_commit_logs_on_project_id"
     t.index ["users_id"], name: "index_github_commit_logs_on_users_id"
   end

--- a/lib/tasks/recreateDB.rake
+++ b/lib/tasks/recreateDB.rake
@@ -11,6 +11,9 @@ namespace :recreateDB do
                 # 一旦削除
                 project.github_commit_logs.destroy_all()
                 # 取得し直す
+                # stats も取得すると、Projectの数によっては一発でアクセス制限にかかるので注意。
+                # ※ 一応、回避方法もないわけではなさそう？ → https://developer.github.com/v3/#rate-limiting
+                puts("URL  :  https://api.github.com/repos/#{user.username}/#{project.name}/commits")
                 commit_logs = JSON.parse(`curl https://api.github.com/repos/#{user.username}/#{project.name}/commits`)
                 puts commit_logs
                 project.save_commit_log(commit_logs)

--- a/lib/tasks/test_hello_world.rake
+++ b/lib/tasks/test_hello_world.rake
@@ -14,4 +14,27 @@ namespace :test_hello_world do
         end
         puts
     end
+
+    task :print_GitHubAPI_test do
+        #print(`curl https://api.github.com/repos/M-82s7503/shrc/commits`)
+        @commit_logs = JSON.parse(`curl https://api.github.com/repos/M-82s7503/shrc/commits`)
+        #print(@commit_logs)
+
+        for log in @commit_logs.reverse do
+            #puts("log : #{log}\n\n")
+            puts("\n\n\nlog['parents'] : #{log['parents']}")
+            # => log['parents'] : [{"sha"=>"db63f3a3097df7d0cd4d342da11e710047a1f897", "url"=>"https://api.gith・・・・f897"}]
+
+            # 空なら取得しない。
+            if log['parents'] != []
+                puts("log['parents'][0]['sha'] : #{log['parents'][0]['sha']}")
+                puts("log['parents'][0]['url'] : #{log['parents'][0]['url']}")
+
+                @c_diffs_url = log['parents'][0]['url']
+                @commit_diffs = JSON.parse(`curl #{@c_diffs_url}`)
+                puts("\n@commit_diffs['stats'] : #{@commit_diffs['stats']}\n\n\n")
+            end
+        end
+    end
+
 end


### PR DESCRIPTION
- コミットごとに、"stats" の total, addition, deletion の数値を取得
- 「DB に保存する」までテスト済み。
　（ project . choose_log_data(log) に追加したので、github_commit_logs を更新するときは
　　必ず呼ばれる仕様になってる。）